### PR TITLE
Fix user credential update in Instapaper auth

### DIFF
--- a/src/instapaper.py
+++ b/src/instapaper.py
@@ -44,7 +44,10 @@ class Instapaper(object):
                 cursor.execute("INSERT INTO users VALUES (%s, %s, %s);", (self._user_id, username, password))
 
             except psycopg2.IntegrityError:
-                cursor.execute("UPDATE users SET id = %(id)s WHERE id = %(id)s;", {'id': user_id})
+                cursor.execute(
+                    "UPDATE users SET username = %s, password = %s WHERE id = %s;",
+                    (username, password, self._user_id),
+                )
 
             connection.commit()
 
@@ -70,4 +73,4 @@ class Instapaper(object):
         """
         Checks if the user is authorized.
         """
-        return True if self._username else None
+        return bool(self._username)


### PR DESCRIPTION
## Summary
- update existing Instapaper users correctly
- return boolean for authorization check

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_688fdb5e5e60832f83b6a5e76401733c